### PR TITLE
chore: update to NDK r28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-android-bindings"
-version = "6.0.0"
+version = "6.0.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-android-bindings"
-version = "6.0.0"
+version = "6.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ ENV SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-809
     ANDROID_HOME="/usr/local/android-sdk" \
     ANDROID_VERSION=31 \
     ANDROID_BUILD_TOOLS_VERSION=32.0.0 \
-    NDK_VERSION="25.2.9519653" \
+    NDK_VERSION="28.0.13004108" \
     PATH="$PATH":/usr/local/bin:/usr/local/google-cloud-sdk/bin \
     GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-294.0.0-linux-x86_64.tar.gz"
 

--- a/lib-wrapper/android-bindings/publish.gradle
+++ b/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '6.0.1'
+version '6.0.2'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()


### PR DESCRIPTION
* Update the Android NDK to r28
* Bump version to 6.0.2 (the current release is 6.0.1, but the Cargo.toml version was still at 6.0.0)