### PR TITLE
update workflow and make file to use new docker builder image

### DIFF
--- a/.github/workflows/android-bindings-dispatch.yaml
+++ b/.github/workflows/android-bindings-dispatch.yaml
@@ -19,5 +19,5 @@ jobs:
         MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
       working-directory: ./
       run: |
-        make ci
+        make publish
 

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ export IAS_MODE ?= PROD
 
 CARGO_PROFILE ?= mobile
 ARCHS = aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
-DOCKER_BUILDER_IMAGE_TAG = gcr.io/mobilenode-211420/android-bindings-builder:1_4
+DOCKER_BUILDER_IMAGE_TAG = mobilecoin/android-bindings-builder:latest
 CARGO_BUILD_FLAGS += -Zunstable-options --profile=$(CARGO_PROFILE)
 BUILD_DEPS_FOLDER = /tmp/build/deps/
 MIN_API_LEVEL = 21
@@ -68,7 +68,10 @@ $(ARCHS):
 
 libs: $(ARCHS) strip copy_artifacts
 
-publish: libs
+release: CARGO_BUILD_FLAGS += --locked
+release: libs
+
+publish: release
 	cd lib-wrapper && \
 	./gradlew build && \
 	./gradlew publish
@@ -120,7 +123,7 @@ docker_image:
 		docker
 
 publish_docker_image: docker_image
-	docker image push $(DOCKER_BUILDER_IMAGE_TAG)
+	echo "Use github actions dispatch workflow to publish a new builder docker image"
 
 clean:
 	docker run \
@@ -143,7 +146,8 @@ bash: setup-docker
 		$(DOCKER_BUILDER_IMAGE_TAG) \
 		bash
 
-setup-docker: docker_image
+setup-docker:
+	docker pull $(DOCKER_BUILDER_IMAGE_TAG)
 	mkdir -p $(BUILD_DEPS_FOLDER)
 
 all: setup-docker clean dist


### PR DESCRIPTION
We don't need to call the docker build/run steps in the `github/workflows/android-bindings-dispatch.yaml`, we just want to run the  libs and publish steps (like its just a plain host we're building on).

Update make file to use pre-built docker image instead of building a new one on `make build`.

Update makefile with new `release` target that sets the `--locked` flag when building. The `publish` target now uses the `release` target which builds the `libs` target...

Disable the docker publish step.  Prefer we publish docker images through the github actions workflow.